### PR TITLE
feat : 출발지 ,목적지 입력했을 때 result card 렌더링 (#74)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,15 +1,27 @@
 'use client';
 import { ChipButton, PlaceCard } from '@/components/search';
 import { SwitchSVG, XSVG } from '@/components/search/assets';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useRecoilValue } from 'recoil';
-import { addressesState } from '@/recoil/search';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { addressesState, pathResultState } from '@/recoil/search';
 import Input from '@/components/search/Input';
+import ResultCards from '@/components/search/ResultCards';
 
 export default function SearchPage() {
   const addresses = useRecoilValue(addressesState);
+  const pathResult = useRecoilValue(pathResultState);
   const [inputType, setInputType] = useState('departure');
+  const resetAddresses = useResetRecoilState(addressesState);
+  useEffect(() => {
+    if (
+      pathResult.arrival.address.length !== 0 &&
+      pathResult.departure.address.length !== 0
+    ) {
+      resetAddresses();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addresses]);
 
   return (
     <Wrap>
@@ -49,6 +61,8 @@ export default function SearchPage() {
             />
           );
         })}
+      {pathResult.arrival.address.length !== 0 &&
+        pathResult.departure.address.length !== 0 && <ResultCards />}
     </Wrap>
   );
 }

--- a/src/components/search/ResultCard.tsx
+++ b/src/components/search/ResultCard.tsx
@@ -1,28 +1,44 @@
+import { IResultProps } from '@/type/search';
 import Link from 'next/link';
 import styled from 'styled-components';
 
-interface IResultCard {
-  link: string;
-}
-
-const ResultCard = (props: IResultCard) => {
-  const { link } = props;
-
+const ResultCard = ({
+  type,
+  totalTime,
+  totalDistance,
+  subPath,
+  index,
+}: IResultProps) => {
+  const lastTime = subPath.map((item) => {
+    return item.lastTime || '';
+  })[subPath.length - 1];
   return (
-    <Link href={link}>
+    <Link prefetch={false} href={`/route/${index.toString()}`}>
       <Wrap>
         <Header>
-          <Type>지하철</Type>
+          <Type>{type}</Type>
           <Right>
             <p>
-              막차 시간 <span>AM00:11</span>
+              막차 시간 <span>{lastTime}</span>
             </p>
             <p>
-              소요 시간 <span>1시간 31분</span>
+              소요 시간 <span>{totalTime}</span>
             </p>
           </Right>
         </Header>
-        <RouteBar></RouteBar>
+        <RouteBar>
+          {/* {subPath.map(({ distance, trafficType, sectionTime }) => {
+            return (
+              {trafficType === 1 ? ''}
+              <>
+              
+                <TestDiv
+                  distance={Math.floor(totalDistance / distance)}
+                ></TestDiv>
+              </>
+            );
+          })} */}
+        </RouteBar>
         <DepartureText>
           <span>16</span>분 뒤에 출발해야해요
         </DepartureText>
@@ -73,6 +89,7 @@ const Type = styled.h1`
 `;
 
 const RouteBar = styled.div`
+  display: flex;
   width: 100%;
   height: 14px;
   border-radius: 100px;
@@ -95,4 +112,9 @@ const DepartureText = styled.p`
     line-height: 34px; /* 141.667% */
     padding-right: 2px;
   }
+`;
+
+const TestDiv = styled.div<{ distance: number; trafficType: string }>`
+  width: ${({ distance }) => distance}%;
+  background-color: red;
 `;

--- a/src/components/search/ResultCards.tsx
+++ b/src/components/search/ResultCards.tsx
@@ -1,0 +1,59 @@
+import { getUserRoute } from '@/api/api';
+import { pathResultState } from '@/recoil/search';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { ResultCard } from '.';
+import { IQueryProps } from '@/type/search';
+
+const ResultCards = () => {
+  const pathResult = useRecoilValue(pathResultState);
+
+  const queryKey = [
+    'userRoute',
+    pathResult.departure.x,
+    pathResult.departure.y,
+    pathResult.arrival.x,
+    pathResult.arrival.y,
+  ];
+
+  const { data, isLoading, isError } = useQuery<IQueryProps[]>({
+    queryKey: queryKey,
+    queryFn: () =>
+      getUserRoute(
+        pathResult.departure.x,
+        pathResult.departure.y,
+        pathResult.arrival.x,
+        pathResult.arrival.y
+      ),
+  });
+
+  if (isLoading) {
+    return <div>로딩중입니다.</div>;
+  }
+
+  if (isError) {
+    return <div>에러입니다.</div>;
+  }
+  return (
+    <>
+      {data && data.length > 0
+        ? data?.map(({ type, totalTime, totalDistance, subPath }, index) => {
+            return (
+              <div key={index}>
+                <ResultCard
+                  type={type}
+                  totalTime={totalTime}
+                  totalDistance={totalDistance}
+                  subPath={subPath}
+                  index={index}
+                />
+              </div>
+            );
+          })
+        : ''}
+    </>
+  );
+};
+
+export default ResultCards;

--- a/src/type/search.ts
+++ b/src/type/search.ts
@@ -5,3 +5,31 @@ export interface IAddressProps {
   x: string;
   y: string;
 }
+
+export interface IResultProps {
+  index: number;
+  type: string;
+  totalTime: number;
+  totalDistance: number;
+  subPath: ISubPath[];
+}
+
+export interface ISubPath {
+  trafficType: string;
+  distance: number;
+  sectionTime: number;
+  startName?: string;
+  endName?: string;
+  stationCount?: number;
+  lastTime?: string;
+}
+
+export interface IQueryProps {
+  firstStartStation: string;
+  lastEndStation: string;
+  payment: number;
+  subPath: ISubPath[];
+  totalDistance: number;
+  totalTime: number;
+  type: string;
+}


### PR DESCRIPTION
## 🚩 이슈 번호
- close #74 

## 📝 작업 내용
- 출발지, 목적지를 모두 입력 했을 때 결과 카드가 나올 수 있도록 했습니다.
![image](https://github.com/makchamakers/makchata/assets/62875596/fe63619d-1a3a-4b0b-afa7-731def7850be)
- styled-components props를 통해서 나누는 것은 다음 이슈에서 작업 하도록 하겠습니다!


## 📣 리뷰 요청사항/알릴사항/질문
- [알릴사항] 아무래도 서버에서 요청하고 응답에 오는 시간이 조금 걸리다 보니 데이터를 불러오는데 로딩 중이라는 사실을 유저한테 알려야 유저가 데이터가 불러와지고 있다는 사실을 알 수 있을 것 같아요! 로딩 컴포넌트는 어떻게 해볼까요?
1. 스피너 만드는 사이트에서 gif 등을 다운 받아서 넣어본다.
2. 서디한테 조심스럽게 요청해본다..